### PR TITLE
Use simple AABB to exit PBCollide() early

### DIFF
--- a/playbox2d/body.c
+++ b/playbox2d/body.c
@@ -11,6 +11,7 @@ PBBody* PBBodyCreate(void) {
   body->force = PBVec2MakeEmpty();
   body->friction = 0.2f;
   body->width = PBVec2Make(1.0f, 1.0f);
+  body->AABBHalfSize = PBVec2GetLength(body->width) * 0.5f;
   body->mass = FLT_MAX;
   body->invMass = 0.0f;
   body->I = FLT_MAX;
@@ -34,6 +35,7 @@ void PBBodySet(PBBody* body, const PBVec2 w, float m) {
   body->friction = 0.2f;
   
   body->width = w;
+  body->AABBHalfSize = PBVec2GetLength(body->width) * 0.5f;
   body->mass = m;
   
   if(m < FLT_MAX) {

--- a/playbox2d/body.h
+++ b/playbox2d/body.h
@@ -12,6 +12,7 @@ typedef struct {
   
   // Properties
   PBVec2 width;
+  float AABBHalfSize;
   float friction;
   float mass, invMass;
   float I, invI;

--- a/playbox2d/collide.c
+++ b/playbox2d/collide.c
@@ -121,6 +121,11 @@ static void ComputeIncidentEdge(PBClipVertex c[2], const PBVec2 h, const PBVec2 
 }
 
 int PBCollide(PBContact* contacts, PBBody* bodyA, PBBody* bodyB) {
+  // Early discard with a simple AABB
+  float AABBSum = bodyA->AABBHalfSize + bodyB->AABBHalfSize;
+  if ( PBAbs(bodyA->position.x-bodyB->position.x)>AABBSum || PBAbs(bodyA->position.y-bodyB->position.y)>AABBSum )
+    return 0;
+    
   // Setup
   PBVec2 hA = PBVec2MultF(bodyA->width, 0.5f);
   PBVec2 hB = PBVec2MultF(bodyB->width, 0.5f);

--- a/playbox2d/playbox.c
+++ b/playbox2d/playbox.c
@@ -117,6 +117,7 @@ int playbox_body_setSize(lua_State* L) {
   PBBody* body = getBodyArg(1);
   body->width.x = pd->lua->getArgFloat(2);
   body->width.y = pd->lua->getArgFloat(3);
+  body->AABBHalfSize = PBVec2GetLength(body->width) * 0.5f;
   return 0;
 }
 


### PR DESCRIPTION
added a simple test to check if two bodies are close to each other. Since PBCollide is called on all possible pairs of bodies is can save a lot of time (in the default example the world update runs 3ms faster)
However AABBHalfSize need to be recalculated each time the width of a body is modified