### PR TITLE
Changes to make the library easily relocatable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,8 @@ PRODUCT = playboxdemo.pdx
 # Locate the SDK
 SDK = $(shell egrep '^\s*SDKRoot' ~/.Playdate/config | head -n 1 | cut -c9-)
 
-VPATH += extension
-VPATH += playbox2d
-
-# List C source files here
-SRC = extension/main.c \
-	playbox2d/array.c \
-	playbox2d/maths.c \
-	playbox2d/body.c \
-	playbox2d/joint.c \
-	playbox2d/collide.c \
-	playbox2d/arbiter.c \
-	playbox2d/world.c \
-	playbox2d/playbox.c
-	
-
 # List all user directories here
-UINCDIR = extension playbox2d
+UINCDIR =
 
 # List user asm files
 UASRC = 
@@ -39,7 +24,10 @@ ULIBDIR =
 # List all user libraries here
 ULIBS =
 
+include playbox2d/playbox2d.mk
+include extension/extension.mk
+
 include $(SDK)/C_API/buildsupport/common.mk
 
 # Make sure we compile for x86 on M1 macs (until simulator supports them)
-DYLIB_FLAGS+=-arch x86_64
+#DYLIB_FLAGS+=-arch x86_64

--- a/extension/extension.mk
+++ b/extension/extension.mk
@@ -1,0 +1,12 @@
+# -- Find out more about where this file is relative to the Makefile including it
+RELATIVE_FILE_PATH := $(lastword $(MAKEFILE_LIST))
+RELATIVE_DIR := $(subst /$(notdir $(RELATIVE_FILE_PATH)),,$(RELATIVE_FILE_PATH))
+RELATIVE_PARENT_DIR := $(subst /$(notdir $(RELATIVE_DIR)),,$(RELATIVE_DIR))
+
+# -- Add us as an include search folder only if it's not already there
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+UINCDIR := $(call uniq, $(UINCDIR) $(RELATIVE_PARENT_DIR))
+
+# -- Add our source files
+SRC := $(SRC) \
+       $(RELATIVE_DIR)/main.c

--- a/extension/main.c
+++ b/extension/main.c
@@ -1,5 +1,5 @@
 #include "pd_api.h"
-#include "playbox.h"
+#include "playbox2d/playbox.h"
 
 PlaydateAPI* pd = NULL;
 

--- a/playbox2d/arbiter.c
+++ b/playbox2d/arbiter.c
@@ -1,5 +1,5 @@
-#include "platform.h"
-#include "arbiter.h"
+#include "playbox2d/platform.h"
+#include "playbox2d/arbiter.h"
 
 PBArbiter* PBArbiterCreate(PBBody* b1, PBBody* b2) {
   PBArbiter* arbiter = pb_alloc(sizeof(PBArbiter));

--- a/playbox2d/arbiter.h
+++ b/playbox2d/arbiter.h
@@ -1,8 +1,8 @@
 #ifndef PLAYBOX_ARBITER_H
 #define PLAYBOX_ARBITER_H
 
-#include "maths.h"
-#include "body.h"
+#include "playbox2d/maths.h"
+#include "playbox2d/body.h"
 #include <stdint.h>
 
 typedef union {

--- a/playbox2d/array.c
+++ b/playbox2d/array.c
@@ -1,5 +1,5 @@
-#include "array.h"
-#include "platform.h"
+#include "playbox2d/array.h"
+#include "playbox2d/platform.h"
 
 PBArray* PBArrayCreate(size_t item_size) {
   PBArray* array = (PBArray*)pb_alloc(sizeof(PBArray));

--- a/playbox2d/body.c
+++ b/playbox2d/body.c
@@ -1,5 +1,5 @@
-#include "platform.h"
-#include "body.h"
+#include "playbox2d/platform.h"
+#include "playbox2d/body.h"
 
 PBBody* PBBodyCreate(void) {
   PBBody* body = pb_alloc(sizeof(PBBody));

--- a/playbox2d/body.h
+++ b/playbox2d/body.h
@@ -1,7 +1,7 @@
 #ifndef PLAYBOX_BODY_H
 #define PLAYBOX_BODY_H
 
-#include "maths.h"
+#include "playbox2d/maths.h"
 
 typedef struct {
   // State

--- a/playbox2d/collide.c
+++ b/playbox2d/collide.c
@@ -1,5 +1,5 @@
-#include "platform.h"
-#include "arbiter.h"
+#include "playbox2d/platform.h"
+#include "playbox2d/arbiter.h"
 
 // Box vertex and edge numbering:
 //

--- a/playbox2d/joint.c
+++ b/playbox2d/joint.c
@@ -1,7 +1,7 @@
-#include "platform.h"
-#include "joint.h"
-#include "body.h"
-#include "maths.h"
+#include "playbox2d/platform.h"
+#include "playbox2d/joint.h"
+#include "playbox2d/body.h"
+#include "playbox2d/maths.h"
 
 PBJoint* PBJointCreate(PBBody* b1, PBBody* b2, const PBVec2 anchor) {
   PBJoint* joint = pb_alloc(sizeof(PBJoint));

--- a/playbox2d/joint.h
+++ b/playbox2d/joint.h
@@ -1,8 +1,8 @@
 #ifndef PLAYBOX_JOINT_H
 #define PLAYBOX_JOINT_H
 
-#include "maths.h"
-#include "body.h"
+#include "playbox2d/maths.h"
+#include "playbox2d/body.h"
 
 typedef struct {
   PBMat22 M;

--- a/playbox2d/maths.c
+++ b/playbox2d/maths.c
@@ -2,7 +2,7 @@
 #include <float.h>
 #include <assert.h>
 #include <stdlib.h>
-#include "maths.h"
+#include "playbox2d/maths.h"
 
 const float pb_pi = 3.14159265358979323846264f;
 

--- a/playbox2d/playbox.c
+++ b/playbox2d/playbox.c
@@ -1,6 +1,6 @@
-#include "playbox.h"
-#include "maths.h"
-#include "platform.h"
+#include "playbox2d/playbox.h"
+#include "playbox2d/maths.h"
+#include "playbox2d/platform.h"
 
 static const lua_reg worldClass[];
 static const lua_reg bodyClass[];

--- a/playbox2d/playbox.h
+++ b/playbox2d/playbox.h
@@ -1,11 +1,11 @@
 #ifndef PLAYBOX_H
 #define PLAYBOX_H
 
-#include "maths.h"
-#include "body.h"
-#include "joint.h"
-#include "arbiter.h"
-#include "world.h"
+#include "playbox2d/maths.h"
+#include "playbox2d/body.h"
+#include "playbox2d/joint.h"
+#include "playbox2d/arbiter.h"
+#include "playbox2d/world.h"
 
 extern void registerPlaybox(void);
 

--- a/playbox2d/playbox2d.mk
+++ b/playbox2d/playbox2d.mk
@@ -1,0 +1,19 @@
+# -- Find out more about where this file is relative to the Makefile including it
+RELATIVE_FILE_PATH := $(lastword $(MAKEFILE_LIST))
+RELATIVE_DIR := $(subst /$(notdir $(RELATIVE_FILE_PATH)),,$(RELATIVE_FILE_PATH))
+RELATIVE_PARENT_DIR := $(subst /$(notdir $(RELATIVE_DIR)),,$(RELATIVE_DIR))
+
+# -- Add us as an include search folder only if it's not already there
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+UINCDIR := $(call uniq, $(UINCDIR) $(RELATIVE_PARENT_DIR))
+
+# -- Add our source files
+SRC := $(SRC) \
+	   $(RELATIVE_DIR)/array.c \
+	   $(RELATIVE_DIR)/maths.c \
+	   $(RELATIVE_DIR)/body.c \
+	   $(RELATIVE_DIR)/joint.c \
+	   $(RELATIVE_DIR)/collide.c \
+	   $(RELATIVE_DIR)/arbiter.c \
+	   $(RELATIVE_DIR)/world.c \
+	   $(RELATIVE_DIR)/playbox.c

--- a/playbox2d/world.c
+++ b/playbox2d/world.c
@@ -1,6 +1,6 @@
-#include "world.h"
-#include "platform.h"
-#include "arbiter.h"
+#include "playbox2d/world.h"
+#include "playbox2d/platform.h"
+#include "playbox2d/arbiter.h"
 
 int PBWorldFindArbiter(PBWorld* world, PBBody* body1, PBBody* body2);
 int PBWorldFindFirstArbiterForBody(PBWorld* world, PBBody* body);

--- a/playbox2d/world.h
+++ b/playbox2d/world.h
@@ -1,11 +1,11 @@
 #ifndef PLAYBOX_WORLD_H
 #define PLAYBOX_WORLD_H
 
-#include "body.h"
-#include "joint.h"
-#include "arbiter.h"
-#include "maths.h"
-#include "array.h"
+#include "playbox2d/body.h"
+#include "playbox2d/joint.h"
+#include "playbox2d/arbiter.h"
+#include "playbox2d/maths.h"
+#include "playbox2d/array.h"
 
 typedef struct {
   PBVec2 gravity;


### PR DESCRIPTION
If someone wants to use playbox2d in their own project, this makes it as easy as a simple `include playbox2d/playbox2d.mk` in their makefile and calling `registerPlaybox()` in an init event.

Include statements are now fully qualified to avoid clashes with other libraries (with something like platform.h for example).